### PR TITLE
Change command for make device serial numbers. for MacOSX.

### DIFF
--- a/android
+++ b/android
@@ -135,7 +135,7 @@ function _adb()
           ;;
         -s)
           # Use 'adb devices' to list serial numbers.
-          COMPREPLY=( $(compgen -W "$(adb devices|tail -n +2|head -n -1|cut -f1)" -- ${cur} ) )
+          COMPREPLY=( $(compgen -W "$(adb devices|grep 'device$'|cut -f1)" -- ${cur} ) )
           return 0
           ;;
       esac


### PR DESCRIPTION
On the Mac OS X, 
$ head -n -1
was
head: illegal line count -- -1

So the 'grep' command was changed to use.
