### PR TITLE
Add serial completion for recovery and sideload modes

### DIFF
--- a/android
+++ b/android
@@ -149,7 +149,8 @@ function _adb()
           ;;
         -s)
           # Use 'adb devices' to list serial numbers.
-          COMPREPLY=( $(compgen -W "$(adb devices|grep 'device$'|cut -f1)" -- ${cur} ) )
+          COMPREPLY=( $(compgen -W "$(adb devices |
+                awk '/(device|recovery|sideload)$/{print $1}')" -- ${cur} ) )
           return 0
           ;;
       esac


### PR DESCRIPTION
Useful for connecting adb with recovery and then sideload updates.