### PR TITLE
Search ip addresses for 'adb [dis]connect'

### DIFF
--- a/android
+++ b/android
@@ -218,6 +218,14 @@ function _adb()
           ;;
       esac
       ;;
+    connect)
+      COMPREPLY=( $(echo `cat ~/.bash_history | egrep '^adb connect' | sort | uniq | sed 's/^adb connect//'`) )
+      return 0
+      ;;
+    disconnect)
+      COMPREPLY=( $(echo `cat ~/.bash_history | egrep '^adb disconnect' | sort | uniq | sed 's/^adb disconnect//'`) )
+      return 0
+      ;;
   esac
 }
 complete -o default -F _adb adb


### PR DESCRIPTION
When we use adb over network, usually a device has the same ip, but it may be the case that do not match. Therefore, I think that it would be useful to be able to search the ips of connected and disconnected devices.

As you can see, I use bash and I believe that this method would not work with other shell. I don't know how you could solve this, but I just wanted to convey the concept and propose a starting point.
